### PR TITLE
Add some more `suff_stat` and `fit_mle` methods and update docs

### DIFF
--- a/R/gamma.R
+++ b/R/gamma.R
@@ -175,10 +175,14 @@ quantile.gamma <- function(d, p, ...) {
 #' @export
 fit_mle.gamma <- function(d, x, ...) {
   ss <- suff_stat(d, x, ...)
-  gamma()
+  stop("`fit_mle` is not implemented for the Gamma distribution yet")
 }
 
 #' Compute the sufficient statistics for a bernoulli distribution from data
+#'
+#'   - `sum`: The sum of the data.
+#'   - `log_sum`: The log of the sum of the data.
+#'   - `samples`: The number of samples in the data.
 #'
 #' @inherit gamma
 #' @export

--- a/R/geometric.R
+++ b/R/geometric.R
@@ -1,16 +1,16 @@
-#' Create a geometric distribution
+#' Create a Geometric distribution
 #'
-#' The geometric distribution can be thought of as a generalization
-#' of the [bernoulli()] distribution where ask: "if I keep flipping a
+#' The Geometric distribution can be thought of as a generalization
+#' of the [Bernoulli()] distribution where we ask: "if I keep flipping a
 #' coin with probability `p` of heads, what is the probability I need
-#' \eqn{k} flips before I get my first heads?" The geometric
-#' distribution is a special case of negative binomial distribution
+#' \eqn{k} flips before I get my first heads?" The Geometric
+#' distribution is a special case of Negative Binomial distribution
 #' with parameters TODO.
 #'
 #' @param p The success probability for the distribution. `p` can be
 #'   any value in [0, 1], and defaults to `0.5`.
 #'
-#' @return A `geometric` object.
+#' @return A `Geometric` object.
 #' @export
 #'
 #' @family discrete distributions
@@ -21,7 +21,7 @@
 #'   <https://alexpghayes.github.io/distributions>, where the math
 #'   will render with additional detail and much greater clarity.
 #'
-#'   In the following, let \eqn{X} be a geometric random variable with
+#'   In the following, let \eqn{X} be a Geometric random variable with
 #'   success probability `p` = \eqn{p}.
 #'
 #'   TODO: multiple parameterizations BLEH (ignore it?)
@@ -54,7 +54,7 @@
 #'
 #' @examples
 #'
-#' g <- geometric(0.3)
+#' g <- Geometric(0.3)
 #' g
 #'
 #' random(g, 10)
@@ -63,92 +63,92 @@
 #' cdf(g, 4)
 #' quantile(g, 0.7)
 #'
-geometric <- function(p = 0.5) {
+Geometric <- function(p = 0.5) {
   d <- list(p = p)
-  class(d) <- c("geometric", "distribution")
+  class(d) <- c("Geometric", "distribution")
   d
 }
 
 #' @export
-print.geometric <- function(x, ...) {
+print.Geometric <- function(x, ...) {
   cat(glue("Geometric distribution (p = {x$p})"))
 }
 
-#' Draw a random sample from a geometric distribution
+#' Draw a random sample from a Geometric distribution
 #'
-#' Please see the documentation of [geometric()] for some properties
-#' of the geometric distribution, as well as extensive examples
+#' Please see the documentation of [Geometric()] for some properties
+#' of the Geometric distribution, as well as extensive examples
 #' showing to how calculate p-values and confidence intervals.
 #'
-#' @inherit geometric examples
+#' @inherit Geometric examples
 #'
-#' @param d A `geometric` object created by a call to [geometric()].
+#' @param d A `Geometric` object created by a call to [Geometric()].
 #' @param n The number of samples to draw. Defaults to `1L`.
 #' @param ... Unused. Unevaluated arguments will generate a warning to
 #'   catch mispellings or other possible errors.
 #'
-#' @family geometric distribution
+#' @family Geometric distribution
 #'
 #' @return An integer vector of length `n`.
 #' @export
 #'
-random.geometric <- function(d, n = 1L, ...) {
+random.Geometric <- function(d, n = 1L, ...) {
   rgeom(n = n, prob = d$p)
 }
 
-#' Evaluate the probability mass function of a geometric distribution
+#' Evaluate the probability mass function of a Geometric distribution
 #'
-#' Please see the documentation of [geometric()] for some properties
-#' of the geometric distribution, as well as extensive examples
+#' Please see the documentation of [Geometric()] for some properties
+#' of the Geometric distribution, as well as extensive examples
 #' showing to how calculate p-values and confidence intervals.
 #'
-#' @inherit geometric examples
-#' @inheritParams random.geometric
+#' @inherit Geometric examples
+#' @inheritParams random.Geometric
 #'
 #' @param x A vector of elements whose probabilities you would like to
 #'   determine given the distribution `d`.
 #' @param ... Unused. Unevaluated arguments will generate a warning to
 #'   catch mispellings or other possible errors.
 #'
-#' @family geometric distribution
+#' @family Geometric distribution
 #'
 #' @return A vector of probabilities, one for each element of `x`.
 #' @export
 #'
-pdf.geometric <- function(d, x, ...) {
+pdf.Geometric <- function(d, x, ...) {
   dgeom(x = x, prob = d$p)
 }
 
-#' @rdname pdf.geometric
+#' @rdname pdf.Geometric
 #' @export
 #'
-log_pdf.geometric <- function(d, x, ...) {
+log_pdf.Geometric <- function(d, x, ...) {
   dgeom(x = x, prob = d$p, log = TRUE)
 }
 
-#' Evaluate the cumulative distribution function of a geometric distribution
+#' Evaluate the cumulative distribution function of a Geometric distribution
 #'
-#' @inherit geometric examples
-#' @inheritParams random.geometric
+#' @inherit Geometric examples
+#' @inheritParams random.Geometric
 #'
 #' @param x A vector of elements whose cumulative probabilities you would
 #'   like to determine given the distribution `d`.
 #' @param ... Unused. Unevaluated arguments will generate a warning to
 #'   catch mispellings or other possible errors.
 #'
-#' @family geometric distribution
+#' @family Geometric distribution
 #'
 #' @return A vector of probabilities, one for each element of `x`.
 #' @export
 #'
-cdf.geometric <- function(d, x, ...) {
+cdf.Geometric <- function(d, x, ...) {
   pgeom(q = x, prob = d$p)
 }
 
-#' Determine quantiles of a geometric distribution
+#' Determine quantiles of a Geometric distribution
 #'
-#' @inherit geometric examples
-#' @inheritParams random.geometric
+#' @inherit Geometric examples
+#' @inheritParams random.Geometric
 #'
 #' @param p A vector of probabilites.
 #' @param ... Unused. Unevaluated arguments will generate a warning to
@@ -157,8 +157,8 @@ cdf.geometric <- function(d, x, ...) {
 #' @return A vector of quantiles, one for each element of `p`.
 #' @export
 #'
-#' @family geometric distribution
+#' @family Geometric distribution
 #'
-quantile.geometric <- function(d, p, ...) {
+quantile.Geometric <- function(d, p, ...) {
   qgeom(p = p, prob = d$p)
 }

--- a/R/geometric.R
+++ b/R/geometric.R
@@ -162,3 +162,37 @@ cdf.Geometric <- function(d, x, ...) {
 quantile.Geometric <- function(d, p, ...) {
   qgeom(p = p, prob = d$p)
 }
+
+#' Fit a Geometric distribution to data
+#'
+#' @param d A `Geometric` object.
+#' @param x A vector of zeroes and ones.
+#'
+#' @return a `Geometric` object
+#' @export
+#'
+fit_mle.Geometric <- function(d, x, ...) {
+  ss <- suff_stat(d, x, ...)
+  Geometric(1 / (ss$trials / ss$experiments + 1))
+}
+
+#' Compute the sufficient statistics for the Geometric distribution from data
+#'
+#' @inheritParams fit_mle.Geometric
+#'
+#' @return A named list of the sufficient statistics of the Geometric
+#'   distribution:
+#'
+#'   - `trials`: The total number of trials ran until the first success.
+#'   - `experiments`: The number of experiments run.
+#'
+#' @export
+#'
+suff_stat.Geometric <- function(d, x, ...) {
+  valid_x <- (x >= 0) & (x %% 1 == 0)
+  if(any(!valid_x)) {
+    stop("`x` must be a vector of positive discrete numbers")
+  }
+  list(trials = sum(x), experiments = length(x))
+}
+

--- a/R/log_normal.R
+++ b/R/log_normal.R
@@ -143,3 +143,37 @@ cdf.log_normal <- function(d, x, ...) {
 quantile.log_normal <- function(d, p, ...) {
   qlnorm(p = p, meanlog = d$log_mu, sdlog = d$log_sigma)
 }
+
+#' Fit a Log-normal distribution to data
+#'
+#' @param d A `log_normal` object created by a call to [log_normal()].
+#' @param x A vector of data.
+#'
+#' @family log_normal distribution
+#'
+#' @return A `log_normal` object.
+#' @export
+#'
+fit_mle.log_normal <- function(d, x, ...) {
+  ss <- suff_stat(d, x, ...)
+  log_normal(ss$mu, ss$sigma)
+}
+
+#' Compute the sufficient statistics for a Log-normal distribution from data
+#'
+#' @inheritParams fit_mle.log_normal
+#'
+#' @return A named list of the sufficient statistics of the normal distribution:
+#'
+#'   - `mu`: The sample mean of the log of the data.
+#'   - `sigma`: The sample standard deviation of the log of the data.
+#'   - `samples`: The number of samples in the data.
+#'
+#' @export
+#'
+suff_stat.log_normal <- function(d, x, ...) {
+  valid_x <- x > 0
+  if(any(!valid_x)) stop("`x` must be a vector of positive real numbers")
+  log_x <- log(x)
+  list(mu = mean(log_x), sigma = sd(log_x), samples = length(x))
+}

--- a/R/uniform.R
+++ b/R/uniform.R
@@ -1,20 +1,20 @@
-#' Create a continuous uniform distribution
+#' Create a continuous Uniform distribution
 #'
 #'
 #' @param a The a parameter. `a` can be any value in the set of real
 #'   numbers. Defaults to `0`.
-#' @param b The a parameter. `b` can be any value in the set of real
+#' @param b The b parameter. `b` can be any value in the set of real
 #'   numbers. It should be strictly bigger than `a`, but if is not, the
 #'   order of the parameters is inverted. Defaults to `1`.
 #'
-#' @return A `uniform` object.
+#' @return A `Uniform` object.
 #' @export
 #'
 #' @family continuous distributions
 #'
 #' @examples
 #'
-#' b <- uniform(1, 2)
+#' b <- Uniform(1, 2)
 #' b
 #'
 #' random(b, 10)
@@ -26,23 +26,23 @@
 #' cdf(b, quantile(b, 0.7))
 #' quantile(b, cdf(b, 0.7))
 #'
-uniform <- function(a = 0, b = 1) {
+Uniform <- function(a = 0, b = 1) {
   d <- list(a = a, b = b)
-  class(d) <- "uniform"
+  class(d) <- c("Uniform", "distribution")
   d
 }
 
 #' @export
-print.uniform <- function(x, ...) {
+print.Uniform <- function(x, ...) {
   if(x$a >  x$b) names(x) <- c("b", "a")
   cat(glue("Continuous uniform distribution (a = {x$a}, b = {x$b})"))
 }
 
-#' Draw a random sample from a continuous uniform distribution
+#' Draw a random sample from a continuous Uniform distribution
 #'
 #' @inherit Uniform examples
 #'
-#' @param d A `uniform` object created by a call to [uniform()].
+#' @param d A `Uniform` object created by a call to [Uniform()].
 #' @param n The number of samples to draw. Defaults to `1L`.
 #' @param ... Unused. Unevaluated arguments will generate a warning to
 #'   catch mispellings or other possible errors.
@@ -50,14 +50,14 @@ print.uniform <- function(x, ...) {
 #' @return A numeric vector containing values in `[a, b]` of length `n`.
 #' @export
 #'
-random.uniform <- function(d, n = 1L, ...) {
+random.Uniform <- function(d, n = 1L, ...) {
   runif(n = n, min = min(d$a, d$b), max = max(d$a, d$b))
 }
 
-#' Evaluate the probability mass function of a continuous uniform distribution
+#' Evaluate the probability mass function of a continuous Uniform distribution
 #'
-#' @inherit uniform examples
-#' @inheritParams random.uniform
+#' @inherit Uniform examples
+#' @inheritParams random.Uniform
 #'
 #' @param x A vector of elements whose probabilities you would like to
 #'   determine given the distribution `d`.
@@ -67,21 +67,21 @@ random.uniform <- function(d, n = 1L, ...) {
 #' @return A vector of probabilities, one for each element of `x`.
 #' @export
 #'
-pdf.uniform <- function(d, x, ...) {
+pdf.Uniform <- function(d, x, ...) {
   dunif(x = x, min = min(d$a, d$b), max = max(d$a, d$b))
 }
 
-#' @rdname pdf.uniform
+#' @rdname pdf.Uniform
 #' @export
 #'
-log_pdf.uniform <- function(d, x, ...) {
+log_pdf.Uniform <- function(d, x, ...) {
   dunif(x = x, min = min(d$a, d$b), max = max(d$a, d$b), log = TRUE)
 }
 
-#' Evaluate the cumulative distribution function of a continuous uniform distribution
+#' Evaluate the cumulative distribution function of a continuous Uniform distribution
 #'
 #' @inherit uniform examples
-#' @inheritParams random.uniform
+#' @inheritParams random.Uniform
 #'
 #' @param x A vector of elements whose cumulative probabilities you would
 #'   like to determine given the distribution `d`.
@@ -91,16 +91,16 @@ log_pdf.uniform <- function(d, x, ...) {
 #' @return A vector of probabilities, one for each element of `x`.
 #' @export
 #'
-cdf.uniform <- function(d, x, ...) {
+cdf.Uniform <- function(d, x, ...) {
   punif(q = x, min = min(d$a, d$b), max = max(d$a, d$b))
 }
 
-#' Determine quantiles of a continuous uniform  distribution
+#' Determine quantiles of a continuous Uniform distribution
 #'
 #' `quantile()` is the inverse of `cdf()`.
 #'
-#' @inherit uniform examples
-#' @inheritParams random.uniform
+#' @inherit Uniform examples
+#' @inheritParams random.Uniform
 #'
 #' @param p A vector of probabilites.
 #' @param ... Unused. Unevaluated arguments will generate a warning to
@@ -109,6 +109,6 @@ cdf.uniform <- function(d, x, ...) {
 #' @return A vector of quantiles, one for each element of `p`.
 #' @export
 #'
-quantile.uniform <- function(d, p, ...) {
+quantile.Uniform <- function(d, p, ...) {
   qunif(p = p, min = min(d$a, d$b), max = max(d$a, d$b))
 }

--- a/R/uniform.R
+++ b/R/uniform.R
@@ -112,3 +112,37 @@ cdf.Uniform <- function(d, x, ...) {
 quantile.Uniform <- function(d, p, ...) {
   qunif(p = p, min = min(d$a, d$b), max = max(d$a, d$b))
 }
+
+#' Fit a Uniform distribution to data
+#'
+#' @param d A `Uniform` object created by a call to [Uniform()].
+#' @param x A vector of data.
+#'
+#' @family Uniform distribution
+#'
+#' @return A `Uniform` object.
+#' @export
+#'
+fit_mle.Uniform <- function(d, x, ...) {
+  ss <- suff_stat(d, x, ...)
+  Uniform(ss$min, ss$max)
+}
+
+
+#' Compute the sufficient statistics for a Uniform distribution from data
+#'
+#' @inheritParams fit_mle.Uniform
+#'
+#' @return A named list of the sufficient statistics of the normal distribution
+#'
+#'   - `min`: The minimum of the data.
+#'   - `max`: The maximum of the data.
+#'   - `samples`: The number of samples in the data.
+#'
+#' @export
+#'
+suff_stat.Uniform <- function(d, x, ...) {
+  valid_x <- is.numeric(x)
+  if(!valid_x) stop("`x` must be a numeric vector")
+  list(min = min(x), max = max(x), samples = length(x))
+}

--- a/tests/testthat/test-bernoulli.R
+++ b/tests/testthat/test-bernoulli.R
@@ -1,25 +1,25 @@
 context("test-bernoulli")
 
-test_that("fit.bernoulli works correctly", {
+test_that("fit.Bernoulli works correctly", {
 
-  expect_equal(fit(bernoulli(), c(0,1)), bernoulli(0.5))
+  expect_equal(fit(Bernoulli(), c(0,1)), Bernoulli(0.5))
 
 })
 
-test_that("suff_stats.bernoulli works correctly", {
+test_that("suff_stats.Bernoulli works correctly", {
 
   ss <- list(successes = 3, failures = 2)
-  expect_equal(suff_stat(bernoulli(), c(1,1,1,0,0)), ss)
+  expect_equal(suff_stat(Bernoulli(), c(1,1,1,0,0)), ss)
 
-  expect_error(suff_stat(bernoulli(), 2))
+  expect_error(suff_stat(Bernoulli(), 2))
 
-  expect_error(suff_stat(bernoulli(), -1))
+  expect_error(suff_stat(Bernoulli(), -1))
 })
 
 
-test_that("likelihood.bernoulli and log_likelihood.bernoulli work correctly", {
+test_that("likelihood.Bernoulli and log_likelihood.Bernoulli work correctly", {
 
-  b <- bernoulli(0.1)
+  b <- Bernoulli(0.1)
   x <- c(1, 1, 0)
 
   expect_equal(likelihood(b, 1), 0.1)

--- a/tests/testthat/test-binomial.R
+++ b/tests/testthat/test-binomial.R
@@ -1,33 +1,33 @@
 context("test-binomial")
 
-test_that("fit.binomial works correctly", {
+test_that("fit.Binomial works correctly", {
 
   # only one trial
-  expect_equal(fit(binomial(1), c(0,1)), binomial(1, 0.5))
+  expect_equal(fit(Binomial(1), c(0,1)), Binomial(1, 0.5))
 
   # many trials
   x <- c(0, rep(100, 99))
-  expect_equal(fit(binomial(100), x), binomial(100, 0.99))
+  expect_equal(fit(Binomial(100), x), Binomial(100, 0.99))
 
   # raises error when data has negative counts
-  expect_error(fit(binomial(1), -1))
+  expect_error(fit(Binomial(1), -1))
 
-  # raises error when data has counts greater than binomial's size
-  expect_error(fit(binomial(1), 2))
+  # raises error when data has counts greater than Binomial's size
+  expect_error(fit(Binomial(1), 2))
 })
 
-test_that("suff_stat.binomial works correctly", {
+test_that("suff_stat.Binomial works correctly", {
 
   ss_1 <- list(successes = 1, experiments = 2, trials = 1)
-  expect_equal(suff_stat(binomial(1), c(0,1)), ss_1)
+  expect_equal(suff_stat(Binomial(1), c(0,1)), ss_1)
 
   ss_2 <- list(successes = 9, experiments = 3, trials = 5)
-  expect_equal(suff_stat(binomial(5), c(3,3,3)), ss_2)
+  expect_equal(suff_stat(Binomial(5), c(3,3,3)), ss_2)
 })
 
-test_that("likelihood.binomial and log_likelihood.binomial work correctly", {
+test_that("likelihood.Binomial and log_likelihood.Binomial work correctly", {
 
-  b <- binomial(size = 10, p = 0.1)
+  b <- Binomial(size = 10, p = 0.1)
   x <- c(1, 1, 0)
 
   expect_equal(likelihood(b, 1), dbinom(1, 10, 0.1))

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -2,7 +2,7 @@ context("test-methods")
 
 test_that("pmf works", {
   N <- normal()
-  B <- bernoulli()
+  B <- Bernoulli()
 
   expect_equal(pmf(N, 0), pdf(N, 0))
   expect_equal(pmf(B, 0), pdf(B, 0))
@@ -10,11 +10,11 @@ test_that("pmf works", {
 
 test_that("fit works", {
   N <- normal()
-  bern <- bernoulli()
-  B <- binomial(10)
+  bern <- Bernoulli()
+  B <- Binomial(10)
 
   expect_equal(normal(1, 0), fit(N, c(1, 1)))
-  expect_equal(bernoulli(), fit(bern, c(0, 1)))
-  expect_equal(binomial(10, 0.5), fit(B, c(5,5)))
+  expect_equal(Bernoulli(), fit(bern, c(0, 1)))
+  expect_equal(Binomial(10, 0.5), fit(B, c(5,5)))
 
 })


### PR DESCRIPTION
Adding methods for fitting:

  * `Geometric`
  * `log_normal`
  * `Uniform` 
 
Also fixed broken tests from renames and changed `fit_mle.gamma` to raise an error because it actually hadn't been implemented in the last pull request. 

I think this closes out the simple cases. I'll move onto the more complex distributions that require `optim` or moment matching next. Need to consider how best to do that. I was thinking of turning `fit` into a method and either calling `fit_mle` if one exists or resorting to an alternative. 